### PR TITLE
Find executable in path + make config file configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,17 +7,28 @@
 
    You need to have PHP-CS-Fixer (https://github.com/FriendsOfPHP/PHP-CS-Fixer) installed
 
+   If it is in your path, it should be detected automatically.
+
+*** configuration with use-package
 #+BEGIN_SRC emacs-lisp
 (use-package php-cs-fixer :ensure nil
    :load-path "~/src/php-cs-fixer.el"
-   :config (setq php-cs-fixer--executable "~/.config/composer/vendor/bin/php-cs-fixer"))
+   :config (setq php-cs-fixer--enable nil)) ;; disable it globally if you plan to enable it per folder
 #+END_SRC
+
+*** fix style on save
+
+    With a buffer-local hook :
+#+BEGIN_SRC emacs-lisp
+  (add-hook 'php-mode-hook
+            (lambda () (add-hook 'before-save-hook #'php-cs-fixer--fix nil 'local)))
+#+END_SRC
+
+In case you setup a ~before-save-hook~, you might want
+to tune ~php-cs-fixer--enable~ to control on which projects it runs.
 
 ** Usage
 
 Run ~php-cs-fixer--fix~ to fix code style for the current buffer. In
 case a .php_cs or .php_cs.dist file is found in the project root (as
 guessed by php-project), it will be used.
-
-In case you setup a ~before-save-hook~, you might want
-to tune ~php-cs-fixer--enable~ to control on which projects it runs.

--- a/php-cs-fixer.el
+++ b/php-cs-fixer.el
@@ -39,20 +39,29 @@
 (defvar php-cs-fixer--executable nil
   "The path to php-cs-fixer.")
 
-(defvar php-cs-fixer--config-dir nil
-  "The directory holding php-cs-fixer config file(s). When nil, it will be guessed.")
+(defvar php-cs-fixer--config-file nil
+  "The path to php-cs-fixer config file. When nil, will be guessed.")
 
 (defvar php-cs-fixer--args '()
-  "List of args to send to php-cs-fixer command.")
+  "List of args for php-cs-fixer command.")
 
 (defvar php-cs-fixer--enable t
-  "Control whether code style fixing should happen.")
+  "Control whether code style fixing happens or not.")
 
-(defun php-cs-fixer--get-config-dir ()
-  "Return config directory of php-cs-fixer."
+(defun php-cs-fixer--get-project-dir ()
+  "Return project directory."
   (directory-file-name
-   (expand-file-name
-    (or php-cs-fixer--config-dir (php-project-get-root-dir)))))
+   (expand-file-name (php-project-get-root-dir))))
+
+(defun php-cs-fixer--find-executable ()
+  "Return path of php-cs-fixer executable."
+  (let ((executable php-cs-fixer--executable))
+    (unless executable
+      (setq executable (executable-find "php-cs-fixer"))
+      (when (not executable (error "Could not find php-cs-fixer in path"))))
+    (unless (file-exists-p executable)
+      (error (format "Could not find php-cs-fixer at path %s" executable)))
+    executable))
 
 ;;;###autoload
 (defun  php-cs-fixer--fix ()
@@ -75,10 +84,11 @@
             (with-temp-file tmpfile
               (insert-buffer-substring-no-properties sourcebuffer))
 
-            (if (zerop (apply 'call-process php-cs-fixer--executable nil msgbuf t
+            (if (zerop (apply 'call-process (php-cs-fixer--find-executable) nil msgbuf t
                               (append (list "fix")
                                       php-cs-fixer--args
                                       (php-cs-fixer--get-config-arg)
+                                      (php-cs-fixer--get-cache-arg tmpfile)
                                       (list tmpfile))))
                 (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
                     (message "Buffer was unchanged by php-cs-fixer")
@@ -91,12 +101,22 @@
 
 (defun php-cs-fixer--get-config-arg ()
   "Look for a config file and return relevant cli argument if found."
-  (cond ((file-exists-p (f-join (php-cs-fixer--get-config-dir) ".php_cs"))
-         (list "--config" (f-join (php-cs-fixer--get-config-dir) ".php_cs")))
-        ((file-exists-p (f-join (php-cs-fixer--get-config-dir) ".php_cs.dist"))
-         (list "--config"(f-join (php-cs-fixer--get-config-dir) ".php_cs.dist")))
+  (if php-cs-fixer--config-file
+      (if (file-exists-p php-cs-fixer--config-file)
+          (list "--config" php-cs-fixer--config-file)
+        (error (format "php-cs-fixer config file %s not found" php-cs-fixer--config-file)))
+    (cond ((file-exists-p (f-join (php-cs-fixer--get-project-dir) ".php_cs"))
+           (list "--config" (f-join (php-cs-fixer--get-project-dir) ".php_cs")))
+          ((file-exists-p (f-join (php-cs-fixer--get-project-dir) ".php_cs.dist"))
+           (list "--config"(f-join (php-cs-fixer--get-project-dir) ".php_cs.dist")))
+          (t ()))))
+
+(defun php-cs-fixer--get-cache-arg (target)
+  "Return --using-cache argument, based on TARGET."
+  (cond ((file-exists-p target)
+         (list "--using-cache" "no"))
         (t ())))
-
+
 ;; this function was adapted from go-mode
 (defun php-cs-fixer--goto-line (line)
   "Goto line LINE."


### PR DESCRIPTION
Let user define executable path or try to find it in path.

Make the config file path configurable or try to find it at the
project root.

Avoid using cache when fix concerns only one file.